### PR TITLE
change the userConfigFolder to use the VendorName/ApplicationName

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -134,6 +134,8 @@ func (p *SqflitePlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 			p.userConfigFolder = filepath.Join(home, ".config")
 		}
 	}
+	p.userConfigFolder = filepath.Join(p.userConfigFolder, p.VendorName, p.ApplicationName)
+
 	if p.debug {
 		log.Println("home dir=", p.userConfigFolder)
 	}


### PR DESCRIPTION
The p.VendorName and p.ApplicationName provided when initializing the
plugin weren't used. Joining the VendorName/ApplicationName to the
userConfigFolder allows multiple flutter applications to have the same
db name.